### PR TITLE
Add a limit filter to the /rankings api endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -230,15 +230,15 @@ async function update_stocks(ranking, page) {
         },
         price: ranking[stock].pp / 100,
         "pp-30": [{
-            date: Date.now() - 1,
-            pp: ranking[stock].pp,
-            price: ranking[stock].pp / 100
-          },
-          {
-            date: Date.now(),
-            pp: ranking[stock].pp,
-            price: ranking[stock].pp / 100
-          }
+          date: Date.now() - 1,
+          pp: ranking[stock].pp,
+          price: ranking[stock].pp / 100
+        },
+        {
+          date: Date.now(),
+          pp: ranking[stock].pp,
+          price: ranking[stock].pp / 100
+        }
         ]
       };
       bulkwrite.push({
@@ -344,12 +344,15 @@ app.get("/api/me", function (req, res) {
 
 //route to get the stocks sorted by their value
 app.get("/api/rankings", function (req, res) {
+
+  // Limit example: /api/rankings?limit=100
+  const filters = { limit: parseInt(req.query.limit, 10) || null };
   res.type("application/json");
-  res.send(get_leaderboard());
+  res.send(get_leaderboard(filters));
 });
 //this function formats and returns the stocks sorted by their value
-function get_leaderboard() {
-  var string = "[";
+function get_leaderboard({ limit }) {
+  // var string = "[";
   var result = [];
   for (stock in stocks) {
     result.push({
@@ -363,12 +366,16 @@ function get_leaderboard() {
   result.sort(function (a, b) {
     return b.price - a.price;
   });
-  for (player in result) {
-    if (player == result.length - 1)
-      string += JSON.stringify(result[player]) + "]";
-    else string += JSON.stringify(result[player]) + ",\n";
+  if (limit) {
+    result = result.slice(0, limit);
   }
-  return string;
+  // Shouldn't be necessary
+  // for (player in result) {
+  //   if (player == result.length - 1)
+  //     string += JSON.stringify(result[player]) + "]";
+  //   else string += JSON.stringify(result[player]) + ",\n";
+  // }
+  return JSON.stringify(result);
 }
 ///*not ready
 //route for buying stock

--- a/app.js
+++ b/app.js
@@ -369,13 +369,13 @@ function get_leaderboard({ limit }) {
   if (limit) {
     result = result.slice(0, limit);
   }
-  // Shouldn't be necessary
+  // Shouldn't be necessary as express will convert arrays/objects to JSON strings
   // for (player in result) {
   //   if (player == result.length - 1)
   //     string += JSON.stringify(result[player]) + "]";
   //   else string += JSON.stringify(result[player]) + ",\n";
   // }
-  return JSON.stringify(result);
+  return result;
 }
 ///*not ready
 //route for buying stock

--- a/app.js
+++ b/app.js
@@ -344,14 +344,18 @@ app.get("/api/me", function (req, res) {
 
 //route to get the stocks sorted by their value
 app.get("/api/rankings", function (req, res) {
-
+  const filters = {};
   // Limit example: /api/rankings?limit=100
-  const filters = { limit: parseInt(req.query.limit, 10) || null };
+  if (req.query.limit) {
+    filters.limit = parseInt(req.query.limit);
+  }
+
   res.type("application/json");
   res.send(get_leaderboard(filters));
 });
 //this function formats and returns the stocks sorted by their value
-function get_leaderboard({ limit }) {
+function get_leaderboard(filters) {
+  const { limit } = filters;
   // var string = "[";
   var result = [];
   for (stock in stocks) {


### PR DESCRIPTION
To improve client side performance, with no filter on the results will return only the number given ordered by price (e.g. top 100 by price)